### PR TITLE
Return service-provided JSON data whenever possible on HTTP error response

### DIFF
--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -110,6 +110,14 @@ class DNSimple(object):
         try:
             handle = urlopen(request)
         except URLError, e:
+            # Don't treat errors as fatal (by raising exception) if it is
+            # possible to return JSON-parseable data from the response instead.
+            try:
+                error_str = e.read()
+                json.loads(error_str)  # Exception unless valid JSON
+                return error_str
+            except:
+                pass
             # Check returned URLError for issues and report 'em
             if hasattr(e, 'reason'):
                 raise DNSimpleException(


### PR DESCRIPTION
This change is small but potentially contentious.

Rather than treating non-success HTTP responses as errors and raising an exception, with this change _any_ non-success response with JSON-parseable body content will return the JSON data instead. This means more work for callers to detect and handle non-success responses, but also more flexibility for handling them.

This was motivated to make it easier to handle "semantic" errors like the 422 you get if you try to re-create a pre-existing domain record. DNSimple replies with a 422 and JSON data including a useful warning message, which data was previously lost.
