### PR TITLE
Refactored library to support DNSimple's v2 API, and added preliminary support for SSL certificates.

### DIFF
--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -7,6 +7,19 @@ http://developer.dnsimple.com/overview/
 __version__ = '0.3.7'
 
 import os.path
+import sys
+
+# Python 2 requires additional modules in order to be
+# able to authenticate DNSimple API's SSL certificate
+if (sys.version_info < (3, 0)):
+    import pkg_resources
+    from pkg_resources import DistributionNotFound
+    dependencies = [
+        'pyopenssl',
+        'ndg-httpsclient',
+        'pyasn1'
+    ]
+    pkg_resources.require(dependencies)
 
 try:
     # Use stdlib's json if available (2.6+)
@@ -34,40 +47,35 @@ class DNSimpleException(Exception):
 
 class DNSimple(object):
     def __init__(self,
-                 username=None, password=None,  # HTTP Basic Auth
-                 email=None, api_token=None,  # API Token Auth
-                 domain_token=None,  # API Domain Token Auth
+                 username=None, password=None,  # HTTP Basic auth
+                 email=None, api_token=None,  # Access token auth
                  sandbox=False):  # Use the testing sandbox.
         """
         Create authenticated API client.
 
-        Provide `email` and `api_token` to use X-DNSimple-Token auth.
+        Provide `email` and `api_token` to use API access token auth.
         Provide `username` and `password` to use HTTP Basic auth.
 
         If neither username/password nor domain/api_token credentials are
         provided, they will be read from the .dnsimple file.
 
-        If both a domain_token and api_token are provided, the api_token
-        credentials are preferred.
-
         If both username/password and email/api_token credentials are provided,
         the API authentication credentials are preferred.
         """
         if sandbox:
-            self.__endpoint = 'https://api.sandbox.dnsimple.com/v1'
+            self.__endpoint = 'https://api.sandbox.dnsimple.com/v2'
         else:
-            self.__endpoint = 'https://api.dnsimple.com/v1'
+            self.__endpoint = 'https://api.dnsimple.com/v2'
 
         self.__user_agent = 'DNSimple Python API {version}'.format(version=__version__)
 
-        if email is None and api_token is None and domain_token is None and username is None and password is None:
-            defaults = dict(os.environ)            
+        if email is None and api_token is None and username is None and password is None:
+            defaults = dict(os.environ)
             defaults.update({
                 'username': None,
                 'password': None,
                 'email': None,
                 'api_token': None,
-                'domain_token': None
             })
             config = configparser.ConfigParser(defaults=defaults)
             for cfg in ['.dnsimple', os.path.expanduser('~/.dnsimple')]:
@@ -79,13 +87,12 @@ class DNSimple(object):
                 password = config.get('DNSimple', 'password')
                 email = config.get('DNSimple', 'email')
                 api_token = config.get('DNSimple', 'api_token')
-                domain_token = config.get('DNSimple', 'domain_token')
             except configparser.NoSectionError:
                 pass
 
-        self.__email, self.__api_token, self.__domain_token = email, api_token, domain_token
+        self.__email, self.__api_token = email, api_token
 
-        if email is None and api_token is None and domain_token is None:
+        if email is None and api_token is None:
             if username is None and password is None:
                 raise DNSimpleException('No authentication details provided.')
             self.__auth_string = self.__get_auth_string(username, password)
@@ -100,9 +107,7 @@ class DNSimple(object):
         Return a HTTP Basic or X-DNSimple-Token authentication header dict.
         """
         if self.__api_token:
-            return {'X-DNSimple-Token': '{email}:{api_token}'.format(email=self.__email, api_token=self.__api_token)}
-        elif self.__domain_token:
-            return {'X-DNSimple-Domain-Token': '{domain_token}'.format(domain_token=self.__domain_token)}
+            return {'Authorization': 'Bearer {api_token}'.format(api_token=self.__api_token)}
         else:
             return {'Authorization': self.__auth_string}
 
@@ -117,7 +122,11 @@ class DNSimple(object):
         headers.update({
             'User-Agent': self.__user_agent,
             'Accept': 'application/json',  # Accept required as per documentation
-            'Content-Type': 'application/json'
+        })
+        # Add the 'Content-Type' header only if data is being sent
+        if data:
+            headers.update({
+                'Content-Type': 'application/json'
         })
         request = Request(method=method, url=url, headers=headers, data=json.dumps(data), params=params)
 
@@ -135,6 +144,7 @@ class DNSimple(object):
             handle = session.send(request)
 
         except ConnectionError:
+            raise
             raise DNSimpleException('Failed to reach a server.')
 
         except HTTPError:
@@ -145,19 +155,36 @@ class DNSimple(object):
         if 400 <= handle.status_code:
             raise DNSimpleException(response)
 
-        return response
+        return response['data']
+
+    # ACCOUNTS
+
+    def whoami(self):
+        """Get details about the current authenticated entity used to access the API."""
+        return self.__rest_helper('/whoami', method='GET')
+
+    def account_id(self):
+        """Get the account ID tied to our username."""
+        accounts = self.__rest_helper('/accounts', method='GET')
+        for account in accounts:
+            if account['email'] == self.__email:
+                return account['id']
+
+    def accounts(self):
+        """Get the accounts the current authenticated entity has access to."""
+        return self.__rest_helper('/accounts', method='GET')
 
     # DOMAINS
 
     def domains(self):
         """Get a list of all domains in your account."""
-        return self.__rest_helper('/domains', method='GET')
+        return self.__rest_helper('/{account}/domains'.format(account=self.account_id()), method='GET')
 
     getdomains = domains  # Alias for backwards-compatibility
 
     def domain(self, id_or_domain_name):
         """Get the details for a specific domain in your account. ."""
-        return self.__rest_helper('/domains/{name}'.format(name=id_or_domain_name), method='GET')
+        return self.__rest_helper('/{account}/domains/{name}'.format(account=self.account_id(), name=id_or_domain_name), method='GET')
 
     getdomain = domain  # Alias for backwards-compatibility
 
@@ -168,13 +195,13 @@ class DNSimple(object):
                 'name': domain_name
             }
         }
-        return self.__rest_helper('/domains', data, method='POST')
+        return self.__rest_helper('/{account}/domains'.format(account=self.account_id()), data, method='POST')
 
     adddomain = add_domain  # Alias for backwards-compatibility
 
     def check(self, domain_name):
         """ Check if domain is available for registration """
-        return self.__rest_helper('/domains/{name}/check'.format(name=domain_name), method='GET')
+        return self.__rest_helper('/{account}/registrar/domains/{name}/check'.format(account=self.account_id(), name=domain_name), method='GET')
 
     def register(self, domain_name, registrant_id=None):
         """
@@ -189,42 +216,38 @@ class DNSimple(object):
                 raise DNSimpleException('Could not find registrant_id! Please specify manually.')
 
         data = {
-            'name': domain_name,
             'registrant_id': registrant_id
         }
-        return self.__rest_helper('/domain_registrations', data=data, method='POST')
+        return self.__rest_helper('/{account}/registrar/domains/{name}/registrations'.format(account=self.account_id(), name=domain_name), data=data, method='POST')
 
     def transfer(self, domain_name, registrant_id):
         """
         Transfer a domain name from another domain registrar into DNSimple.
         """
         data = {
-            'domain': {
-                'name': domain_name,
-                'registrant_id': registrant_id
-            }
+            'registrant_id': registrant_id
         }
-        return self.__rest_helper('/domain_transfers', data=data, method='POST')
+        return self.__rest_helper('/{account}/registrar/domains/{name}/transfers'.format(account=self.account_id(), name=domain_name), data=data, method='POST')
 
     def delete(self, id_or_domain_name):
         """
         Delete the given domain from your account. You may use either the
         domain ID or the domain name.
         """
-        return self.__rest_helper('/domains/{name}'.format(name=id_or_domain_name), method='DELETE')
+        return self.__rest_helper('/{account}/domains/{name}'.format(account=self.account_id(), name=id_or_domain_name), method='DELETE')
 
     # RECORDS
 
     def records(self, id_or_domain_name):
         """ Get the list of records for the specific domain """
-        return self.__rest_helper('/domains/{name}/records'.format(name=id_or_domain_name), method='GET')
+        return self.__rest_helper('/{account}/zones/{name}/records'.format(account=self.account_id(), name=id_or_domain_name), method='GET')
 
     getrecords = records  # Alias for backwards-compatibility
 
     def record(self, id_or_domain_name, record_id):
         """ Get details about a specific record """
         return self.__rest_helper(
-            '/domains/{name}/records/{id}'.format(name=id_or_domain_name, id=record_id), method='GET')
+            '/{account}/zones/{name}/records/{id}'.format(account=self.account_id(), name=id_or_domain_name, id=record_id), method='GET')
 
     getrecorddetail = record  # Alias for backwards-compatibility
 
@@ -233,19 +256,17 @@ class DNSimple(object):
         Create a record for the given domain.
 
         `data` parameter is a dictionary that must contain:
-        - 'record_type' : E.g. 'MX', 'CNAME' etc
         - 'name' : E.g. domain prefix for CNAME
+        - 'type' : E.g. 'MX', 'CNAME' etc
         - 'content'
 
         `data` may also contain:
         - 'ttl'
-        - 'prio'
+        - 'priority'
+        - 'regions'
         """
-        data = {
-            'record': data
-        }
-        return self.__rest_helper('/domains/{domain}/records'
-                                  .format(domain=id_or_domain_name), data=data, method='POST')
+        return self.__rest_helper('/{account}/zones/{domain}/records'
+                                  .format(account=self.account_id(), domain=id_or_domain_name), data=data, method='POST')
 
     def update_record(self, id_or_domain_name, record_id, data):
         """
@@ -255,30 +276,28 @@ class DNSimple(object):
         - 'name'
         - 'content'
         - 'ttl'
-        - 'prio'
+        - 'priority'
+        - 'regions'
         """
-        data = {
-            'record': data
-        }
-        return self.__rest_helper('/domains/{domain}/records/{record}'
-                                  .format(domain=id_or_domain_name, record=record_id), data=data, method='PUT')
+        return self.__rest_helper('/{account}/zones/{domain}/records/{record}'
+                                  .format(account=self.account_id(), domain=id_or_domain_name, record=record_id), data=data, method='PATCH')
 
     updaterecord = update_record  # Alias for backwards-compatibility
 
     def delete_record(self, id_or_domain_name, record_id):
         """ Delete the record with the given ID for the given domain """
-        return self.__rest_helper('/domains/{domain}/records/{record}'
-                                  .format(domain=id_or_domain_name, record=record_id), method='DELETE')
+        return self.__rest_helper('/{account}/zones/{domain}/records/{record}'
+                                  .format(account=self.account_id(), domain=id_or_domain_name, record=record_id), method='DELETE')
 
-    # # CONTACTS
+    # CONTACTS
 
     def contacts(self):
         """Get a list of all domain contacts in your account."""
-        return self.__rest_helper('/contacts', method='GET')
+        return self.__rest_helper('/{account}/contacts'.format(account=self.account_id()), method='GET')
 
     def contact(self, contact_id):
         """Get a domain contact."""
-        return self.__rest_helper('/contacts/{contact}'.format(contact=contact_id), method='GET')
+        return self.__rest_helper('/{account}/contacts/{contact}'.format(account=self.account_id(), contact=contact_id), method='GET')
 
     def add_contact(self, data):
         """
@@ -292,17 +311,70 @@ class DNSimple(object):
         - `state_province`
         - `postal_code`
         - `country`
-        - `email_address`
+        - `email`
         - `phone`
+        - `fax`
 
         The `data` dictionary may also contain:
+        - `label`
+        - `address2`
         - `organization_name`
         - `job_title` is required when `organization_name` is present
-        - `phone_ext`
-        - `fax`
-        - `label`
         """
-        data = {
-            'contact': data
-        }
-        return self.__rest_helper('/contacts', data=data, method='POST')
+        return self.__rest_helper('/{account}/contacts'.format(account=self.account_id()), data=data, method='POST')
+
+    # SSL CERTIFICATES
+
+    def certificates(self, id_or_domain_name):
+        """Get a list of all certificates for the specific domain"""
+        return self.__rest_helper('/{account}/domains/{name}/certificates?sort=expires_on:desc,id:desc'.format(account=self.account_id(), name=id_or_domain_name), method='GET')
+
+    def certificate_id(self, id_or_domain_name, id_or_certificate_name):
+        """Get a list of certificate ids for a specific domain"""
+        cert_ids = []
+        certs = self.certificates(id_or_domain_name)
+
+        for cert in certs:
+            if cert['name'] == id_or_certificate_name:
+                cert_ids.append(cert['id'])
+                print cert['id'], cert['name'], cert['expires_on']
+
+        return cert_ids
+
+    def certificate(self, id_or_domain_name, id_or_certificate_name):
+        """
+        Get the certificate for a specific domain
+        
+        If the ID of the certificate is given, we try to get the certificate by its ID.
+        If the name of the certificate is given, we get the latest certificate, whether
+        it's active or expired.
+        """
+        certificate_id = []
+        if id_or_certificate_name.isdigit():
+            certificate_id.append(id_or_certificate_name)
+        else:
+            certificate_id += self.certificate_id(id_or_domain_name, id_or_certificate_name)
+
+            if len(certificate_id) == 0:
+                raise DNSimpleException("Could not find a certificate id for '%s'. Please specify it manually." % id_or_certificate_name)
+
+        return self.__rest_helper('/{account}/domains/{name}/certificates/{id}'.format(account=self.account_id(), name=id_or_domain_name, id=certificate_id[0]), method='GET')
+
+    def private_key(self, id_or_domain_name, id_or_certificate_name):
+        """
+        Get the certificate's private key for a specific domain
+        
+        If the ID of the certificate is given, we try to get the certificate's private
+        key by its certificate ID. If the name of the certificate is given, we get the
+        latest certificate's private key, whether it's active or expired.
+        """
+        certificate_id = []
+        if id_or_certificate_name.isdigit():
+            certificate_id.append(id_or_certificate_name)
+        else:
+            certificate_id += self.certificate_id(id_or_domain_name, id_or_certificate_name)
+
+            if len(certificate_id) == 0:
+                raise DNSimpleException("Could not find a certificate id for '%s'. Please specify it manually." % id_or_certificate_name)
+
+        return self.__rest_helper('/{account}/domains/{name}/certificates/{id}/private_key'.format(account=self.account_id(), name=id_or_domain_name, id=certificate_id[0]), method='GET')

--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -381,7 +381,11 @@ class DNSimple(object):
 
         cert = self.__rest_helper('/{account}/domains/{name}/certificates/{id}'.format(account=self.account_id(), name=id_or_domain_name, id=certificate_id[0]), method='GET')
         cert_dl = self.certificate_download(id_or_domain_name, id_or_certificate_name)
-        return dict(cert.items() + cert_dl.items())
+        cert_key = self.private_key(id_or_domain_name, id_or_certificate_name)
+        cert.update(cert_dl)
+        cert.update(cert_key)
+
+        return cert
 
     def certificate_download(self, id_or_domain_name, id_or_certificate_name):
         """
@@ -420,16 +424,3 @@ class DNSimple(object):
                 raise DNSimpleException("Could not find a certificate id for '%s'. Please specify it manually." % id_or_certificate_name)
 
         return self.__rest_helper('/{account}/domains/{name}/certificates/{id}/private_key'.format(account=self.account_id(), name=id_or_domain_name, id=certificate_id[0]), method='GET')
-
-    def certificate_withkey(self, id_or_domain_name, id_or_certificate_name):
-        """
-        Get the CSR, root, chain and server certificates, as well as private key for
-        a specific domain
-
-        If the ID of the certificate is given, we try to get the certificate by its ID.
-        If the name of the certificate is given, we get the latest certificate, whether
-        it's active or expired.
-        """
-        cert = self.certificate(id_or_domain_name, id_or_certificate_name)
-        key = self.private_key(id_or_domain_name, id_or_certificate_name)
-        return dict(cert.items() + key.items())

--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -345,7 +345,14 @@ class DNSimple(object):
     # SSL CERTIFICATES
 
     def certificates(self, id_or_domain_name):
-        """Get a list of all certificates (and their CSRs) for the specific domain"""
+        """
+        Get a list of all certificates for a specific domain
+
+        DNSimple API v2 does not provide the server certificate or private key
+        anymore through this endpoint; it only includes the CSR in its response.
+        While we fetch the certificates and private key in certificate(), this
+        would be too intensive to do here.
+        """
         params = {
             'sort': 'expires_on:desc,id:desc'
         }
@@ -364,11 +371,12 @@ class DNSimple(object):
 
     def certificate(self, id_or_domain_name, id_or_certificate_name):
         """
-        Get the CSR, root, chain, and server certificates for a specific domain
+        Get the CSR, root, chain, and server certificates, as well as private key
+        for a specific domain
 
-        If the ID of the certificate is given, we try to get the certificate by its ID.
-        If the name of the certificate is given, we get the latest certificate, whether
-        it's active or expired.
+        If the ID of the certificate is given, we try to get the certificates/private
+        key by its ID. If the name of the certificate is given, we get the latest
+        certificate, whether it's active or expired.
         """
         certificate_id = []
         if id_or_certificate_name.isdigit():

--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -337,7 +337,6 @@ class DNSimple(object):
         for cert in certs:
             if cert['name'] == id_or_certificate_name:
                 cert_ids.append(cert['id'])
-                print cert['id'], cert['name'], cert['expires_on']
 
         return cert_ids
 
@@ -378,3 +377,24 @@ class DNSimple(object):
                 raise DNSimpleException("Could not find a certificate id for '%s'. Please specify it manually." % id_or_certificate_name)
 
         return self.__rest_helper('/{account}/domains/{name}/certificates/{id}/private_key'.format(account=self.account_id(), name=id_or_domain_name, id=certificate_id[0]), method='GET')
+
+    def certificate_withkey(self, id_or_domain_name, id_or_certificate_name):
+        """
+        Get the certificate and private key for a specific domain
+
+        If the ID of the certificate is given, we try to get the certificate by its ID.
+        If the name of the certificate is given, we get the latest certificate, whether
+        it's active or expired.
+        """
+        certificate_id = []
+        if id_or_certificate_name.isdigit():
+            certificate_id.append(id_or_certificate_name)
+        else:
+            certificate_id += self.certificate_id(id_or_domain_name, id_or_certificate_name)
+
+            if len(certificate_id) == 0:
+                raise DNSimpleException("Could not find a certificate id for '%s'. Please specify it manually." % id_or_certificate_name)
+
+        cert = self.__rest_helper('/{account}/domains/{name}/certificates/{id}'.format(account=self.account_id(), name=id_or_domain_name, id=certificate_id[0]), method='GET')
+        cert[u'private_key'] = self.private_key(id_or_domain_name, id_or_certificate_name)['private_key']
+        return cert


### PR DESCRIPTION
As you probably know, DNSimple's v1 API has been discontinued since October 1st. I am a DNSimple customer, and I also use Ansible pretty heavily in my day to day -- this library is used by its 'dnsimple' network module which means that this module hasn't been working since the v1 API was shut down.

I basically modified the existing functions to support DNSimple's v2 API (I added a few like '/whoami' and '/accounts') and also added preliminary support for SSL certificates/private keys.