### PR TITLE
Refactor auth to fix basic auth & v2 auth documentation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.markdown
+include README.md

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,14 @@ ci-test:
 	py.test tests
 
 deploy: setup
+	git diff-index --quiet HEAD -- || git stash
+	git checkout master
+	git pull origin master
+	git pull origin master --tags
+	gem install github_changelog_generator
+	github_changelog_generator --future-release=$(VERSION)
 	git tag $(VERSION)
+	git push
 	git push --tags
 	rm dist/*
 	./env/bin/python setup.py sdist

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Python DNSimple
 ===============
 
+[![Build Status](https://travis-ci.org/onlyhavecans/dnsimple-python.svg?branch=master)](https://travis-ci.org/onlyhavecans/dnsimple-python)o
+
 ## Introduction
 
 This is a client for the [DNSimple REST API](https://developer.dnsimple.com/). It currently allows you to fetch existing domain info, as well as register new domains and manage domain records.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a client for the [DNSimple REST API](https://developer.dnsimple.com/). I
 
 `dnsimple-python` works for both python 2 & 3.
 
-**Note:** As of 1.0.0 this now uses [DNSimple's APIv2](https://blog.dnsimple.com/2016/12/api-v2-stable/). This has some incompatibilities with APIv1, including auth changes. Please test for breakages before use.
+**Note:** As of 1.0.0 this now uses [DNSimple's APIv2](https://blog.dnsimple.com/2016/12/api-v2-stable/). This is incompatible with older versions of the library because of authentication changes. Please review the docs and tests before deploying to production.
 
 ### Getting started
 
@@ -23,25 +23,25 @@ from dnsimple import DNSimple
 
 You can provide your DNSimple credentials in one of two ways:
 
-#### Provide username/password or email/api\_token credentials programmatically:
+#### Provide email/password or api\_token credentials programmatically:
 
 ```python
-# Use username/password authentication: HTTP Basic
-dns = DNSimple(username=YOUR_USERNAME, password=YOUR_PASSWORD)
+# Use email/password authentication: HTTP Basic
+dns = DNSimple(email=YOUR_USERNAME, password=YOUR_PASSWORD)
 
-# Use email/api_token credentials
+# Use api_token credentials
 dns = DNSimple(api_token=YOUR_API_TOKEN)
 
 # If you have many accounts you can provide account_id (661 is an example)
 # You can find your account id in url (https://sandbox.dnsimple.com/a/661/account)
-dns = DNSimple(username=YOUR_USERNAME, password=YOUR_PASSWORD, account_id=661)
+dns = DNSimple(email=YOUR_USERNAME, password=YOUR_PASSWORD, account_id=661)
 ```
 
-##### Store you username/password or email/api\_token credentials in a file called `.dnsimple` in the current directory with the following data:
+##### Store you email/password or api\_token credentials in a file called `.dnsimple` in the current directory with the following data:
 
 ```
 [DNSimple]
-username: email@domain.com
+email: email@domain.com
 password: yourpassword
 ```
 
@@ -172,3 +172,4 @@ Licensed under the [MIT license](http://www.opensource.org/licenses/mit-license.
 
 * Original Author [Mike MacCana](https://github.com/mikemaccana/)
 * APIv2 Support [Kirill Motkov](https://github.com/lcd1232)
+* Maintainer [David Aronsohn](https://github.com/onlyhavecans)

--- a/dnsimple/__init__.py
+++ b/dnsimple/__init__.py
@@ -1,5 +1,5 @@
 # Make DNSimple available directly from module for backwards-compatibility
 try:
-    from dnsimple import DNSimple, DNSimpleException
+    from dnsimple import DNSimple, DNSimpleException, DNSimpleAuthException
 except ImportError:
-    from dnsimple.dnsimple import DNSimple, DNSimpleException
+    from dnsimple.dnsimple import DNSimple, DNSimpleException, DNSimpleAuthException

--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -26,7 +26,7 @@ except ImportError:
     pass  # Issues with setup.py needed to import module but the `request` dependency hasn't been installed yet.
 
 
-version = (1, 0, 0)
+version = (1, 0, 1)
 __version__ = '.'.join(str(x) for x in version)
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,7 +6,6 @@ from dnsimple import DNSimple
 @pytest.fixture
 def client():
     return DNSimple(
-        # email     = os.getenv('DNSIMPLE_EMAIL'),
         api_token = os.getenv('DNSIMPLE_API_TOKEN'),
         sandbox   = True
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ import os
 
 from .fixtures import *
 
-from dnsimple import DNSimple, DNSimpleException
+from dnsimple import DNSimple, DNSimpleException, DNSimpleAuthException
 
 @pytest.fixture
 def credentials_file():
@@ -24,32 +24,31 @@ class TestAuth(object):
             pass
 
     def test_authentication_with_no_credentials_raises(self):
-        with pytest.raises(DNSimpleException) as exception:
+        with pytest.raises(DNSimpleAuthException) as exception:
             client = DNSimple()
 
-        assert 'No authentication details provided.' in str(exception.value)
+        assert 'insufficient authentication details provided.' in str(exception.value)
 
     def test_authentication_with_invalid_credentials_raises(self):
         with pytest.raises(DNSimpleException) as exception:
-            client = DNSimple(username = 'user@host.com', password = 'bogus')
+            client = DNSimple(email='user@host.com', password='bogus')
             client.domains()
 
         assert 'Authentication failed' in str(exception.value)
 
     def test_basic_authentication_raises_no_exceptions(self):
         client = DNSimple(
-            username = os.getenv('DNSIMPLE_EMAIL'),
-            password = os.getenv('DNSIMPLE_PASSWORD'),
-            sandbox  = True
+            email=os.getenv('DNSIMPLE_EMAIL'),
+            password=os.getenv('DNSIMPLE_PASSWORD'),
+            sandbox=True
         )
 
         client.domains()
 
     def test_user_token_auth_raises_no_exception(self):
         client = DNSimple(
-            email     = os.getenv('DNSIMPLE_EMAIL'),
-            api_token = os.getenv('DNSIMPLE_API_TOKEN'),
-            sandbox   = True
+            api_token=os.getenv('DNSIMPLE_API_TOKEN'),
+            sandbox=True
         )
 
         client.domains()
@@ -59,7 +58,6 @@ class TestAuth(object):
         file = open(credentials_file, 'w')
         file.writelines([
             "[DNSimple]\n",
-            "email: {0}\n".format(os.getenv('DNSIMPLE_EMAIL')),
             "api_token: {0}\n".format(os.getenv('DNSIMPLE_API_TOKEN'))
         ])
         file.close()


### PR DESCRIPTION
* fix authentication docs in readme
* Implement requests.auth.BasicAuth instead of crafting header directly
* Remove `username` as it is redundant with `email` in APIv2
* clean up choosing logic
* Add a DNSimpleAuthException
* add build badge to readme
* minor fix to Manifest
* update build process