### PR TITLE
Fix for #32: pip dependency installation fails

### DIFF
--- a/dnsimple/__init__.py
+++ b/dnsimple/__init__.py
@@ -3,3 +3,5 @@ try:
     from dnsimple import DNSimple, DNSimpleException, DNSimpleAuthException
 except ImportError:
     from dnsimple.dnsimple import DNSimple, DNSimpleException, DNSimpleAuthException
+except NameError:
+    pass

--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -25,9 +25,7 @@ try:
 except ImportError:
     pass  # Issues with setup.py needed to import module but the `request` dependency hasn't been installed yet.
 
-
-version = (1, 0, 1)
-__version__ = '.'.join(str(x) for x in version)
+from .dnsimple_version import version, __version__
 
 
 class DNSimpleException(Exception):

--- a/dnsimple/dnsimple_version.py
+++ b/dnsimple/dnsimple_version.py
@@ -3,7 +3,7 @@
 Client for DNSimple REST API
 http://developer.dnsimple.com/overview/
 """
-version = (1, 0, 1)
+version = (1, 0, 3)
 __version__ = '.'.join(str(x) for x in version)
 
 

--- a/dnsimple/dnsimple_version.py
+++ b/dnsimple/dnsimple_version.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""
+Client for DNSimple REST API
+http://developer.dnsimple.com/overview/
+"""
+version = (1, 0, 1)
+__version__ = '.'.join(str(x) for x in version)
+
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from setuptools import setup, find_packages
 
-from dnsimple import dnsimple
+from dnsimple import dnsimple_version as dnsimple
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'), 'r') as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
Due to a circular dependency, where `setup.py`, in order to determine the version, imports the `dnsimple` module, which has as dependency the `requests` module, which - if not present - results in errors.